### PR TITLE
Update to Swift 2.2

### DIFF
--- a/TKSwarmAlert/Classes/BrightView.swift
+++ b/TKSwarmAlert/Classes/BrightView.swift
@@ -39,8 +39,8 @@ class BrightView: UIView {
     func addBrightLayer() {
         let radius:CGFloat = self.frame.height + self.frame.width
         let path:CGMutablePath = CGPathCreateMutable()
-        func makeFanShapedPathDeviedBy18(var i:Int) {
-            i = i % 18
+        func makeFanShapedPathDeviedBy18(i:Int) {
+            let i = i % 18
             let oneAngle = CGFloat(M_PI) / 9
             let startAngle = oneAngle * CGFloat(i)
             let endAngle = startAngle + oneAngle

--- a/TKSwarmAlert/Classes/FallingAnimationView.swift
+++ b/TKSwarmAlert/Classes/FallingAnimationView.swift
@@ -147,7 +147,7 @@ class FallingAnimationView: UIView {
         // make it draggable
         for v in views {
 //            dev_makeLine(v)
-            v.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: "didDrag:"))
+            v.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(FallingAnimationView.didDrag(_:))))
             v.tag = startPoints.count
             startPoints.append(v.center)
             currentAnimationViewTags.append(v.tag)
@@ -307,7 +307,7 @@ class FallingAnimationView: UIView {
     }
     
     func enableTapGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: "onTapSuperView")
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(FallingAnimationView.onTapSuperView))
         self.addGestureRecognizer(tapGesture)
     }
     


### PR DESCRIPTION
Fixes:
- Warnings: "Use of string literal for Objective-C selectors is deprecated; use '#selector' instead"

- 'var' parameters are deprecated and will be removed in Swift 3